### PR TITLE
Added ids back to events

### DIFF
--- a/DayPlanner/Data/Event.swift
+++ b/DayPlanner/Data/Event.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-struct Event: Equatable, Hashable, Codable {
+struct Event: Equatable, Identifiable, Codable {
+    var id: String = UUID().uuidString
     var startTime: Date? = nil
     var duration: Int = 900000 //Stored in milliseconds for compatibility with android
     var eventName: String = ""

--- a/DayPlanner/UI/List/EventList.swift
+++ b/DayPlanner/UI/List/EventList.swift
@@ -37,7 +37,7 @@ struct EventList: View {
         
         let list = ScrollView {
             VStack (spacing: 10) {
-                ForEach(app.eventList, id: \.self) {
+                ForEach(app.eventList, id: \.self.id) {
                     (event: Event) in VStack { ListItem(event: event) }
                         .opacity(event == draggedEvent ? 0.1 : 1)
                         .onDrag {


### PR DESCRIPTION
Because there were some bugs that couldn't be solved without doing that. It will cause some incompatibility with Android, but that will have to be fixed later.